### PR TITLE
Changes to Health Icon (Dynamic Icon Frames Support)

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -20,6 +20,7 @@ Add stage shader effects by JSON
 Fix icon offsets
 Heatwave shader
 Fix PlaybackRate
+Fix bugs with health icons
 
 
 Done:

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -70,7 +70,7 @@ class HealthIcon extends FlxSprite
 
 	public dynamic function updateFrame(health:Float):Void {
 		for (healthPercent => frame in animationMap)
-			if (health < healthPercent)
+			if (health < healthPercent && animationMap.exists(animation.curAnim.numFrames))
 				animation.curAnim.curFrame = frame;
 	}
 

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -27,6 +27,9 @@ class HealthIcon extends FlxSprite
 
 		if (sprTracker != null)
 			setPosition(sprTracker.x + sprTracker.width + 12, sprTracker.y - 30);
+
+		updateFrame(isPlayer ? PlayState.instance.healthBar.percent : 100 - PlayState.instance.healthBar.percent);
+
 	}
 
 	inline public function swapOldIcon():Void {

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -29,7 +29,8 @@ class HealthIcon extends FlxSprite
 			setPosition(sprTracker.x + sprTracker.width + 12, sprTracker.y - 30);
 
 		if (PlayState.instance != null)
-			updateFrame(isPlayer ? PlayState.instance.healthBar.percent * 3 + 50 : PlayState.instance.healthBar.percent - 50);
+			// TODO: fix win icons if they're broken
+			updateFrame(isPlayer ? PlayState.instance.healthBar.percent * 3 + 45 : PlayState.instance.healthBar.percent - 85);
 		else
 		{
 			// I forgot this was dynamic :skull:

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -29,13 +29,12 @@ class HealthIcon extends FlxSprite
 			setPosition(sprTracker.x + sprTracker.width + 12, sprTracker.y - 30);
 
 		updateFrame(isPlayer ? PlayState.instance.healthBar.percent : 100 - PlayState.instance.healthBar.percent);
+		offset.y = 0;
 	}
 
 	inline public function swapOldIcon():Void {
 		(isOldIcon = !isOldIcon) ? changeIcon('bf-old') : changeIcon('bf');
 	}
-
-	private var iconOffsets:FlxPoint = new FlxPoint(0, 0);
 
 	public function changeIcon(char:String):Void {
 		if(this.char != char) {
@@ -44,25 +43,19 @@ class HealthIcon extends FlxSprite
 			if(!Paths.fileExists('images/' + name + '.png', IMAGE)) name = 'icons/icon-face'; //Prevents crash from missing icon
 			var file:Dynamic = Paths.image(name);
 
-			loadGraphic(file); //Get file size
-			loadGraphic(file, true, Math.floor(Math.abs(width)), Math.floor(Math.abs(height))); //Then load it fr
+			loadGraphic(file); //load graphic to get the width and height
+
+			var dumbWidth:Int = Std.int(file.width / 150);
+			loadGraphic(file, true, Std.int(width / dumbWidth), Std.int(file.height)); //Then load it fr
 
 			animation.add(char, [for (i in 0...frames.frames.length) i], 0, false, isPlayer);
 			animation.play(char);
 			this.char = char;
 
-			iconOffsets.set((width - 150) / frames.frames.length, (height - 150) / frames.frames.length);
-
 			antialiasing = (ClientPrefs.globalAntialiasing && !char.endsWith('-pixel'));
 			scrollFactor.set();
 			updateHitbox();
 		}
-	}
-
-	override function updateHitbox():Void
-	{
-		super.updateHitbox();
-		offset = iconOffsets;
 	}
 
 	/**

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -77,7 +77,7 @@ class HealthIcon extends FlxSprite
 
 	public dynamic function updateFrame(health:Float):Void {
 		for (healthPercent => frame in animationMap)
-			if (health < healthPercent && animation.frames >= frame)
+			if (health < healthPercent)
 				animation.curAnim.curFrame = frame;
 	}
 

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -28,7 +28,14 @@ class HealthIcon extends FlxSprite
 		if (sprTracker != null)
 			setPosition(sprTracker.x + sprTracker.width + 12, sprTracker.y - 30);
 
-		updateFrame(isPlayer ? PlayState.instance.healthBar.percent : 100 - PlayState.instance.healthBar.percent);
+		if (PlayState.instance != null)
+			updateFrame(isPlayer ? PlayState.instance.healthBar.percent * 3 + 50 : PlayState.instance.healthBar.percent - 50);
+		else
+		{
+			// I forgot this was dynamic :skull:
+			updateFrame = fakeHealth -> animation.curAnim.curFrame = Std.int(fakeHealth);
+			// updateFrame(0);
+		}
 		offset.y = 0;
 	}
 
@@ -41,11 +48,11 @@ class HealthIcon extends FlxSprite
 			var name:String = 'icons/' + char;
 			if(!Paths.fileExists('images/' + name + '.png', IMAGE)) name = 'icons/icon-' + char; //Older versions of psych engine's support
 			if(!Paths.fileExists('images/' + name + '.png', IMAGE)) name = 'icons/icon-face'; //Prevents crash from missing icon
-			var file:Dynamic = Paths.image(name);
+			final file:Dynamic = Paths.image(name);
 
 			loadGraphic(file); //load graphic to get the width and height
 
-			var dumbWidth:Int = Std.int(file.width / 150);
+			final dumbWidth:Int = Std.int(file.width / 150);
 			loadGraphic(file, true, Std.int(width / dumbWidth), Std.int(file.height)); //Then load it fr
 
 			animation.add(char, [for (i in 0...frames.frames.length) i], 0, false, isPlayer);
@@ -65,16 +72,15 @@ class HealthIcon extends FlxSprite
 	public var animationMap:Map<Int, Int> = [
 		0 => 0, // Default
 		20 => 1, // Lose
-		80 => 2, // Winning
+		80 => 2 // Winning
 	];
 
 	public dynamic function updateFrame(health:Float):Void {
 		for (healthPercent => frame in animationMap)
-			if (health < healthPercent && animationMap.exists(animation.curAnim.numFrames))
+			if (health < healthPercent)
 				animation.curAnim.curFrame = frame;
 	}
 
-	inline public function getCharacter():String {
+	inline public function getCharacter():String
 		return char;
-	}
 }

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -1,7 +1,7 @@
 package;
 
 import flixel.FlxSprite;
-import openfl.utils.Assets as OpenFlAssets;
+import flixel.math.FlxPoint;
 
 using StringTools;
 
@@ -29,7 +29,6 @@ class HealthIcon extends FlxSprite
 			setPosition(sprTracker.x + sprTracker.width + 12, sprTracker.y - 30);
 
 		updateFrame(isPlayer ? PlayState.instance.healthBar.percent : 100 - PlayState.instance.healthBar.percent);
-
 	}
 
 	inline public function swapOldIcon():Void {
@@ -46,7 +45,7 @@ class HealthIcon extends FlxSprite
 			var file:Dynamic = Paths.image(name);
 
 			loadGraphic(file); //Get file size
-			loadGraphic(file, true, 150, 150); //Then load it fr
+			loadGraphic(file, true, Math.floor(Math.abs(width)), Math.floor(Math.abs(height))); //Then load it fr
 
 			animation.add(char, [for (i in 0...frames.frames.length) i], 0, false, isPlayer);
 			animation.play(char);
@@ -72,8 +71,8 @@ class HealthIcon extends FlxSprite
 	 */
 	public var animationMap:Map<Int, Int> = [
 		0 => 0, // Default
-		20 => 1 // Lose
-		80 => 2 // Winning
+		20 => 1, // Lose
+		80 => 2, // Winning
 	];
 
 	public dynamic function updateFrame(health:Float):Void {

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3550,37 +3550,6 @@ class PlayState extends MusicBeatState
 		if (health > maxHealth)
 			health = maxHealth;
 
-		// fixing the yandere dev code
-		switch (iconP1.animation.numFrames){
-			case 3:
-				if (healthBar.percent < 20)
-					iconP1.animation.curAnim.curFrame = 1;
-				else if (healthBar.percent > 80)
-					iconP1.animation.curAnim.curFrame = 2;
-				else
-					iconP1.animation.curAnim.curFrame = 0;
-			case 2:
-				if (healthBar.percent < 20)
-					iconP1.animation.curAnim.curFrame = 1;
-				else
-					iconP1.animation.curAnim.curFrame = 0;
-		}
-		// player 2
-		switch (iconP2.animation.numFrames){
-			case 3:
-				if (healthBar.percent > 80)
-					iconP2.animation.curAnim.curFrame = 1;
-				else if (healthBar.percent < 20)
-					iconP2.animation.curAnim.curFrame = 2;
-				else
-					iconP2.animation.curAnim.curFrame = 0;
-			case 2:
-				if (healthBar.percent > 80)
-					iconP2.animation.curAnim.curFrame = 1;
-				else
-					iconP2.animation.curAnim.curFrame = 0;
-		}
-
 		if (FlxG.keys.anyJustPressed(debugKeysCharacter) && !endingSong && !inCutscene)
 		{
 			var ret:Dynamic = callOnLuas('onCharacterEditor', []);

--- a/source/ResetScoreSubState.hx
+++ b/source/ResetScoreSubState.hx
@@ -57,6 +57,7 @@ class ResetScoreSubState extends MusicBeatSubstate
 			icon.updateHitbox();
 			icon.setPosition(text.x - icon.width + (10 * tooLong), text.y - 30);
 			icon.alpha = 0;
+			// icon.updateFrame = null;
 			add(icon);
 		}
 
@@ -115,6 +116,7 @@ class ResetScoreSubState extends MusicBeatSubstate
 		yesText.scale.set(scales[confirmInt], scales[confirmInt]);
 		noText.alpha = alphas[1 - confirmInt];
 		noText.scale.set(scales[1 - confirmInt], scales[1 - confirmInt]);
-		if(week == -1) icon.animation.curAnim.curFrame = confirmInt;
+		if(week == -1)
+			icon.updateFrame = daHealth -> icon.animation.curAnim.curFrame = confirmInt;
 	}
 }


### PR DESCRIPTION
remains untested for now
old code bothered me in multiple ways and I hated the way I did it so I'm just rewriting it

idk what this engine uses for scripting necessarily but modifying the frame indexes should be as easy as calling `iconP1.animationMap.set(50, 4);` now, in this example `50` is health percentage, and 4 is frame number 4 on the image

I can't really test the changes at the moment because I can't compile the game and it's very late at night by the time I'm writing this so please help me out with testing these, it's kinda annoying not being able to test stuff